### PR TITLE
(SIMP-1573) Remove extraneous `require 'pry'`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+### 0.1.1 / 2016-09-28
+* Bug fix:
+  * Removed extraneous `require 'pry'` from `release_mapper.rb`
+
+
 ### 0.1.0 / 2016-02-03
 
 * Initial release:

--- a/lib/simp/build/helpers/version.rb
+++ b/lib/simp/build/helpers/version.rb
@@ -21,7 +21,7 @@ module Simp
   module Build
     module Helpers
       # simp-build-helpers version
-      VERSION = "0.1.0"
+      VERSION = "0.1.1"
     end
   end
 end

--- a/lib/simp/build/release_mapper.rb
+++ b/lib/simp/build/release_mapper.rb
@@ -1,6 +1,4 @@
 require 'yaml'
-require 'pry'
-
 
 module Simp::Build
   class SIMPBuildException < Exception; end


### PR DESCRIPTION
Before this patch, the `require 'pry'` statement in
**release_mapper.rb** was breaking Travis CI builds of subscriber gems,
such as `rubygem-simp-rake-helpers`.  This commit removes the line.

SIMP-1573 #comment Removed extraneous `require 'pry'`
SIMP-1573 #close #comment Bumped gem version to `0.1.1`